### PR TITLE
add `seekFile` to AVFormatContext and Expose AVFormatContext inner c AVFormatContext pointer in a convenient way 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 SwiftFFmpeg.xcodeproj/
 docs/
+
+
+.DS_Store
+.swiftpm/

--- a/Sources/SwiftFFmpeg/AVFormatContext.swift
+++ b/Sources/SwiftFFmpeg/AVFormatContext.swift
@@ -446,6 +446,34 @@ extension AVFormatContext {
     public func seekFrame(to timestamp: Int64, streamIndex: Int, flags: SeekFlag) throws {
         try throwIfFail(av_seek_frame(cContextPtr, Int32(streamIndex), timestamp, flags.rawValue))
     }
+    
+    
+
+   
+    
+    /// Seek to timestamp ts.
+    ///
+    /// - Parameters:
+    ///   - timeStamp: Timestamp in `AVStream.timebase` units or, if no stream is specified,
+    ///     in `AVTimestamp.timebase` units.
+    ///   - streamIndex: If `streamIndex` is -1, a default stream is selected, and timestamp
+    ///     is automatically converted from `AVTimestamp.timebase` units to the stream specific timebase.
+    ///   - minTimeStamp: smallest acceptable timestamp.
+    ///   - maxTimeStamp: largest acceptable timestamp.
+    ///   - flags: flags which select direction and seeking mode.
+    /// - Throws: AVError
+    public func seekFile(to timeStamp: Int64, streamIndex: Int, minTimeStamp: Int64, maxTimeStamp: Int64,flags: SeekFlag) throws {
+        try throwIfFail(
+            avformat_seek_file(
+                cContextPtr,
+                Int32(streamIndex),
+                minTimeStamp,
+                timeStamp,
+                maxTimeStamp,
+                flags.rawValue
+            )
+        )
+    }
 
     /// Discard all internally buffered data. This can be useful when dealing with
     /// discontinuities in the byte stream. Generally works only with formats that

--- a/Sources/SwiftFFmpeg/AVFormatContext.swift
+++ b/Sources/SwiftFFmpeg/AVFormatContext.swift
@@ -688,7 +688,7 @@ public struct AVFormatContextInternals {
     }
 }
 extension AVFormatContext {
-    var `internal`: AVFormatContextInternals {
+    public var `internal`: AVFormatContextInternals {
         return AVFormatContextInternals(value: self)
     }
 }

--- a/Sources/SwiftFFmpeg/AVFormatContext.swift
+++ b/Sources/SwiftFFmpeg/AVFormatContext.swift
@@ -9,7 +9,7 @@ import CFFmpeg
 
 // MARK: - AVFormatContext
 
-typealias CAVFormatContext = CFFmpeg.AVFormatContext
+public typealias CAVFormatContext = CFFmpeg.AVFormatContext
 
 /// Format I/O context.
 public final class AVFormatContext {
@@ -677,5 +677,18 @@ extension AVFormatContext: AVClassSupport, AVOptionSupport {
         _ body: (UnsafeMutableRawPointer) throws -> T
     ) rethrows -> T {
         try body(cContextPtr)
+    }
+}
+
+// MARK: - AVFormatContextInternals
+public struct AVFormatContextInternals {
+    let value: AVFormatContext
+    public var cContextPtr: UnsafeMutablePointer<CAVFormatContext>! {
+        return value.cContextPtr
+    }
+}
+extension AVFormatContext {
+    var `internal`: AVFormatContextInternals {
+        return AVFormatContextInternals(value: self)
     }
 }


### PR DESCRIPTION
ignore `.DS_Store` and `.swiftpm`