### PR TITLE
mismatch between the Swift function type declarations and the C function type declarations

### DIFF
--- a/Sources/SwiftFFmpeg/AVIO.swift
+++ b/Sources/SwiftFFmpeg/AVIO.swift
@@ -19,7 +19,7 @@ typealias CAVIOContext = CFFmpeg.AVIOContext
 
 public typealias AVIOReadHandler = (UnsafeMutableRawPointer?, UnsafeMutablePointer<UInt8>?, Int) ->
   Int
-public typealias AVIOWriteHandler = (UnsafeMutableRawPointer?, UnsafeMutablePointer<UInt8>?, Int) ->
+public typealias AVIOWriteHandler = (UnsafeMutableRawPointer?, UnsafePointer<UInt8>?, Int) ->
   Int
 public typealias AVIOSeekHandler = (UnsafeMutableRawPointer?, Int64, Int) -> Int64
 
@@ -76,7 +76,7 @@ public final class AVIOContext {
       }
     }
     var write:
-      (@convention(c) (UnsafeMutableRawPointer?, UnsafeMutablePointer<UInt8>?, Int32) -> Int32)?
+      (@convention(c) (UnsafeMutableRawPointer?, UnsafePointer<UInt8>?, Int32) -> Int32)?
     if writeHandler != nil {
       write = { opaque, buffer, size -> Int32 in
         let value = Unmanaged<IOBox>.fromOpaque(opaque!).takeUnretainedValue().value


### PR DESCRIPTION


The write handler in the C API expects a const buffer (which maps to UnsafePointer in Swift) since it shouldn't modify the data it's writing, while the Swift type declaration uses a mutable pointer.

This matches the C API's expectation that the write handler won't modify the buffer it's writing. The read handler keeps the mutable pointer since it needs to fill the buffer with data. This type safety is actually helping prevent potential bugs where the write handler might accidentally modify the source buffer, which isn't intended in the FFmpeg API design.