### PR TITLE
XVMC (X-Video Motion Compensation) is an obsolete technology that has been deprecated and removed from FFmpeg.

### DIFF
--- a/Sources/SwiftFFmpeg/AVPixelFormat.swift
+++ b/Sources/SwiftFFmpeg/AVPixelFormat.swift
@@ -352,9 +352,6 @@ extension AVPixelFormat {
   /// bayer, GRGR..(odd line), BGBG..(even line), 16-bit samples, big-endian */
   public static let BAYER_GRBG16BE = AV_PIX_FMT_BAYER_GRBG16BE
 
-  /// XVideo Motion Acceleration via common packet passing
-  public static let XVMC = AV_PIX_FMT_XVMC
-
   /// planar YUV 4:4:0,20bpp, (1 Cr & Cb sample per 1x2 Y samples), little-endian
   public static let YUV440P10LE = AV_PIX_FMT_YUV440P10LE
   /// planar YUV 4:4:0,20bpp, (1 Cr & Cb sample per 1x2 Y samples), big-endian


### PR DESCRIPTION


By removing this constant, i intent to help keep the codebase clean and preventing developers from accidentally trying to use a pixel format that isn't supported in modern FFmpeg versions.