### PR TITLE
Some improvements

### DIFF
--- a/Sources/SwiftFFmpeg/AVCodec.swift
+++ b/Sources/SwiftFFmpeg/AVCodec.swift
@@ -97,6 +97,34 @@ extension AVCodecID {
   public static let APE = AV_CODEC_ID_APE
   public static let MP1 = AV_CODEC_ID_MP1
 
+    // MARK: - Subtitle Codecs
+
+    public static let HDMV_PGS_SUBTITLE = AV_CODEC_ID_HDMV_PGS_SUBTITLE
+    public static let DVB_TELETEXT = AV_CODEC_ID_DVB_TELETEXT
+    public static let SRT = AV_CODEC_ID_SRT
+    public static let MICRODVD = AV_CODEC_ID_MICRODVD
+    public static let DST = AV_CODEC_ID_DST
+    public static let FIRST_SUBTITLE = AV_CODEC_ID_FIRST_SUBTITLE
+    public static let DVD_SUBTITLE = AV_CODEC_ID_DVD_SUBTITLE
+    public static let DVB_SUBTITLE = AV_CODEC_ID_DVB_SUBTITLE
+    public static let TEXT = AV_CODEC_ID_TEXT
+    public static let XSUB = AV_CODEC_ID_XSUB
+    public static let SSA = AV_CODEC_ID_SSA
+    public static let MOV_TEXT = AV_CODEC_ID_MOV_TEXT
+    public static let EIA_608 = AV_CODEC_ID_EIA_608
+    public static let JACOSUB = AV_CODEC_ID_JACOSUB
+    public static let SAMI = AV_CODEC_ID_SAMI
+    public static let REALTEXT = AV_CODEC_ID_REALTEXT
+    public static let STL = AV_CODEC_ID_STL
+    public static let SUBVIEWER1 = AV_CODEC_ID_SUBVIEWER1
+    public static let SUBVIEWER = AV_CODEC_ID_SUBVIEWER
+    public static let SUBRIP = AV_CODEC_ID_SUBRIP
+    public static let WEBVTT = AV_CODEC_ID_WEBVTT
+    public static let MPL2 = AV_CODEC_ID_MPL2
+    public static let VPLAYER = AV_CODEC_ID_VPLAYER
+    public static let PJS = AV_CODEC_ID_PJS
+    public static let ASS = AV_CODEC_ID_ASS
+    public static let HDMV_TEXT_SUBTITLE = AV_CODEC_ID_HDMV_TEXT_SUBTITLE
   /// The name of the codec.
   public var name: String {
     String(cString: avcodec_get_name(self))

--- a/Sources/SwiftFFmpeg/AVIO.swift
+++ b/Sources/SwiftFFmpeg/AVIO.swift
@@ -184,7 +184,7 @@ public final class AVIOContext {
   /// - Throws: AVError
   public func size() throws -> Int64 {
     let ret = avio_size(native)
-    try throwIfFail(Int32(ret))
+    try throwIfFail(Int32(clamping: ret))
     return ret
   }
 

--- a/Sources/SwiftFFmpeg/SwsContext.swift
+++ b/Sources/SwiftFFmpeg/SwsContext.swift
@@ -34,7 +34,7 @@ public final class SwsContext {
     sws_isSupportedEndiannessConversion(pixelFormat) > 0
   }
 
-  let native: OpaquePointer
+  let native: UnsafeMutablePointer<CFFmpeg.SwsContext>
 
   /// Creates an empty context.
   public init() {
@@ -128,38 +128,38 @@ extension SwsContext {
   ///
   public struct Flag: OptionSet {
     /// Select fast bilinear scaling algorithm.
-    public static let fastBilinear = Flag(rawValue: SWS_FAST_BILINEAR)
+      public static let fastBilinear = Flag(rawValue: Int32(SWS_FAST_BILINEAR.rawValue))
     /// Select bilinear scaling algorithm.
-    public static let bilinear = Flag(rawValue: SWS_BILINEAR)
+    public static let bilinear = Flag(rawValue: Int32(SWS_BILINEAR.rawValue))
     /// Select bicubic scaling algorithm.
-    public static let bicubic = Flag(rawValue: SWS_BICUBIC)
+    public static let bicubic = Flag(rawValue: Int32(SWS_BICUBIC.rawValue))
     /// Select experimental scaling algorithm.
-    public static let x = Flag(rawValue: SWS_X)
+    public static let x = Flag(rawValue: Int32(SWS_X.rawValue))
     /// Select nearest neighbor rescaling algorithm.
-    public static let point = Flag(rawValue: SWS_POINT)
+    public static let point = Flag(rawValue: Int32(SWS_POINT.rawValue))
     /// Select averaging area rescaling algorithm.
-    public static let area = Flag(rawValue: SWS_AREA)
+    public static let area = Flag(rawValue: Int32(SWS_AREA.rawValue))
     /// Select bicubic scaling algorithm for the luma component, bilinear for chroma components.
-    public static let bicublin = Flag(rawValue: SWS_BICUBLIN)
+    public static let bicublin = Flag(rawValue: Int32(SWS_BICUBLIN.rawValue))
     /// Select Gaussian rescaling algorithm.
-    public static let gauss = Flag(rawValue: SWS_GAUSS)
+    public static let gauss = Flag(rawValue: Int32(SWS_GAUSS.rawValue))
     /// Select sinc rescaling algorithm.
-    public static let sinc = Flag(rawValue: SWS_SINC)
+    public static let sinc = Flag(rawValue: Int32(SWS_SINC.rawValue))
     /// Select Lanczos rescaling algorithm.
-    public static let lanczos = Flag(rawValue: SWS_LANCZOS)
+    public static let lanczos = Flag(rawValue: Int32(SWS_LANCZOS.rawValue))
     /// Select natural bicubic spline rescaling algorithm.
-    public static let spline = Flag(rawValue: SWS_SPLINE)
+    public static let spline = Flag(rawValue: Int32(SWS_SPLINE.rawValue))
 
     /// Enable printing/debug logging.
-    public static let printInfo = Flag(rawValue: SWS_PRINT_INFO)
+    public static let printInfo = Flag(rawValue: Int32(SWS_PRINT_INFO.rawValue))
     /// Enable full chroma interpolation.
-    public static let fullChromaInt = Flag(rawValue: SWS_FULL_CHR_H_INT)
+    public static let fullChromaInt = Flag(rawValue: Int32(SWS_FULL_CHR_H_INT.rawValue))
     /// Select full chroma input.
-    public static let fullChromaInp = Flag(rawValue: SWS_FULL_CHR_H_INP)
+    public static let fullChromaInp = Flag(rawValue: Int32(SWS_FULL_CHR_H_INP.rawValue))
     /// Enable accurate rounding.
-    public static let accurateRnd = Flag(rawValue: SWS_ACCURATE_RND)
+    public static let accurateRnd = Flag(rawValue: Int32(SWS_ACCURATE_RND.rawValue))
     /// Enable bitexact output.
-    public static let bitexact = Flag(rawValue: SWS_BITEXACT)
+    public static let bitexact = Flag(rawValue: Int32(SWS_BITEXACT.rawValue))
 
     public let rawValue: Int32
 


### PR DESCRIPTION
- Added Swift accessibility of subtitles formats.
- Corrected a crash when throwing AVError (I am not sure it is the best solution but at least it does not crash anymore).
- Specifying `let native: OpaquePointer` constant type more precisely (`UnsafeMutablePointer<CFFmpeg.SwsContext>`) to allow compilation.
- Improving C++ `enum` to swift `Flag` conversion to allow compilation.

By the way, thanks for the work, I have been using it for my Subs Factory app for a long time !
